### PR TITLE
fixed download path of segemehl version 0.2.0

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -52,7 +52,7 @@ Some comments:
 
 ::
 
-  curl http://www.bioinf.uni-leipzig.de/Software/segemehl/segemehl_0_2_0.tar.gz > segemehl_0_2_0.tar.gz
+  curl www.bioinf.uni-leipzig.de/Software/segemehl/old/segemehl_0_2_0.tar.gz > segemehl_0_2_0.tar.gz
   tar xzf segemehl_0_2_0.tar.gz
   cd segemehl_*/segemehl/ && make && cd ../../
 


### PR DESCRIPTION
segemehl version 0.3.0 has been released. The download path of the older version 0.2.0 moved to another location. In the future Segemehl version 0.3.0 will be integrated to Reademption. For the time being we recommend using version 0.2.0